### PR TITLE
Add support for meta data convertion

### DIFF
--- a/wordpress-xml-to-json.py
+++ b/wordpress-xml-to-json.py
@@ -63,7 +63,7 @@ for post in document['rss']['channel']['item']:
       'timestamp': get_timestamp(post['wp:post_date']),
       'content'  : post['content:encoded'],
       'comments' : get_comments_from_post(post),
-      'metas'    : get_metadata_from_post(post),
+      'meta_data': get_metadata_from_post(post),
     }
 
 print(dumps(posts, indent=2))

--- a/wordpress-xml-to-json.py
+++ b/wordpress-xml-to-json.py
@@ -36,6 +36,21 @@ def get_comments_from_post(post):
             comments.append(get_comment_dict(comment))
     return comments
 
+def get_meta_dict(meta):
+    return {
+        'meta_key' : meta['wp:meta_key'],
+        'meta_value': meta['wp:meta_value'],
+    }
+
+def get_metadata_from_post(post):
+    if 'wp:postmeta' not in post:
+      return []
+    metadata = []
+    for meta in post['wp:postmeta']:
+      if isinstance(meta, dict):
+        metadata.append(get_meta_dict(meta))
+    return metadata
+
 posts = {}
 
 for post in document['rss']['channel']['item']:
@@ -48,6 +63,7 @@ for post in document['rss']['channel']['item']:
       'timestamp': get_timestamp(post['wp:post_date']),
       'content'  : post['content:encoded'],
       'comments' : get_comments_from_post(post),
+      'metas'    : get_metadata_from_post(post),
     }
 
 print(dumps(posts, indent=2))

--- a/wordpress-xml-to-json.py
+++ b/wordpress-xml-to-json.py
@@ -57,6 +57,7 @@ for post in document['rss']['channel']['item']:
     name = post['wp:post_name']
     posts[name] = {
       'name'     : name,
+      'post_id'  : post['wp:post_id'],
       'link'     : post['link'],
       'title'    : post['title'],
       'date'     : post['wp:post_date'],


### PR DESCRIPTION
Post metadata is commonly used when you have a plugin like ACF installed. Would be nice to export those fields along with the fields you provided.
